### PR TITLE
P11

### DIFF
--- a/src/main/scala/example/P11.scala
+++ b/src/main/scala/example/P11.scala
@@ -1,6 +1,6 @@
 package example
 
-import Util.map
+import java.util.map
 import P09.pack
 import P04.length
 
@@ -14,10 +14,10 @@ import P04.length
 
 object P11 {
   def encodeModified(list:List[T]):List[T] = {
-    map(pack(list)){x =>
+    Map(pack(list)){x =>
       length(x) match {
         case 1 => x.head
-        case _ => (i, x.head)
+        case i => (i, x.head)
       }
     }
   }

--- a/src/main/scala/example/P11.scala
+++ b/src/main/scala/example/P11.scala
@@ -6,14 +6,15 @@ import P04.length
 
 /**
  * Modified run-length encoding.
- * Modify the result of problem P10 in such a way that if an element has no duplicates it is simply copied into the result list. Only elements with duplicates are transferred as (N, E) terms.
+ * Modify the result of problem P10 in such a way that if an element has no duplicates it is simply copied into the result list.
+ * Only elements with duplicates are transferred as (N, E) terms.
  * Example:
  * scala> encodeModified(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
  * res0: List[Any] = List((4,'a), 'b, (2,'c), (2,'a), 'd, (4,'e))
  */
 
 object P11 {
-  def encodeModified(list: List[T]): List[T] = {
+  def encodeModified(list: List[Any]): List[Any] = {
     map(pack(list)){ x =>
       length(x) match {
         case 1 => x.head

--- a/src/main/scala/example/P11.scala
+++ b/src/main/scala/example/P11.scala
@@ -1,0 +1,24 @@
+package example
+
+import Util.map
+import P09.pack
+import P04.length
+
+/**
+ * Modified run-length encoding.
+ * Modify the result of problem P10 in such a way that if an element has no duplicates it is simply copied into the result list. Only elements with duplicates are transferred as (N, E) terms.
+ * Example:
+ * scala> encodeModified(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
+ * res0: List[Any] = List((4,'a), 'b, (2,'c), (2,'a), 'd, (4,'e))
+ */
+
+object P11 {
+  def encodeModified(list:List[T]):List[T] = {
+    map(pack(list)){x =>
+      length(x) match {
+        case 1 => x.head
+        case _ => (i, x.head)
+      }
+    }
+  }
+}

--- a/src/main/scala/example/P11.scala
+++ b/src/main/scala/example/P11.scala
@@ -1,6 +1,6 @@
 package example
 
-import java.util.map
+import scala.util.map
 import P09.pack
 import P04.length
 
@@ -13,8 +13,8 @@ import P04.length
  */
 
 object P11 {
-  def encodeModified(list:List[T]):List[T] = {
-    Map(pack(list)){x =>
+  def encodeModified(list: List[T]): List[T] = {
+    map(pack(list)){ x =>
       length(x) match {
         case 1 => x.head
         case i => (i, x.head)

--- a/src/main/scala/example/Util.scala
+++ b/src/main/scala/example/Util.scala
@@ -1,0 +1,7 @@
+package example
+
+object Util {
+  def map[A, B](list:List[])(f: (B, A) => B):List[B] = {
+    ???
+  }
+}

--- a/src/main/scala/example/Util.scala
+++ b/src/main/scala/example/Util.scala
@@ -1,7 +1,9 @@
 package example
 
 object Util {
-  def map[A, B](list:List[])(f: (B, A) => B):List[B] = {
-    ???
+  def map[A, B](list:List[A])(f:A => B):List[B] =
+    list match {
+      case x :: xs => f(x) :: map(xs)(f)
+      case Nil => Nil
   }
 }


### PR DESCRIPTION
### 設問
Modified run-length encoding.
Modify the result of problem P10 in such a way that if an element has no duplicates it is simply copied into the result list. Only elements with duplicates are transferred as (N, E) terms.
Example:

scala> encodeModified(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
res0: List[Any] = List((4,'a), 'b, (2,'c), (2,'a), 'd, (4,'e))