### PR TITLE
P14

### DIFF
--- a/src/main/scala/example/P07.scala
+++ b/src/main/scala/example/P07.scala
@@ -1,0 +1,45 @@
+package jp.co.example
+
+import scala.annotation.tailrec
+
+/**
+ * Reverse a list.
+ * Example:
+ * scala> reverse(List(1, 1, 2, 3, 5, 8))
+ * res0: List[Int] = List(8, 5, 3, 2, 1, 1)
+ */
+object P05 {
+  def foldLeft[A, B](list: List[A], b: B)(f: (B, A) => B): B = {
+    list match {
+      case x :: xs => foldLeft(xs, f(b, x))(f)
+      case Nil => b
+    }
+  }
+  def reverse[T](list:List[T]): List[T] = {
+    foldLeft(list, List[T]()){(b, a) => a::b}
+  }
+}
+
+// 末尾再帰のアノテーション @tailrec を利用した解答例があった
+//object P05 {
+//  def reverse[T](list: List[T]): List[T] = {
+//    @tailrec
+//    def go(rem: List[T], acc: List[T]): List[T] =
+//      rem match {
+//        case Nil     => acc
+//        case x :: xs => go(xs, x :: acc)
+//      }
+//    go(list, Nil)
+//  }
+//}
+
+// 末尾再帰とは
+// 関数aが他関数を呼び出すとき最後(末尾)に呼ばれるもの
+// 以下でいうと関数c, dが末尾再帰となる
+//def a() {
+//  if b() {
+//  c()
+//  } else {
+//  d()
+//  }
+//}

--- a/src/main/scala/example/P14.scala
+++ b/src/main/scala/example/P14.scala
@@ -1,5 +1,11 @@
 package example
 
+import Util.flatMap
+
 object P14 {
-  def duplicate() = {}
+  def duplicate[T](list: List[T]):List[T] = {
+    flatMap(list){
+      case x => List(x, x)
+    }
+  }
 }

--- a/src/main/scala/example/P14.scala
+++ b/src/main/scala/example/P14.scala
@@ -1,0 +1,5 @@
+package example
+
+object P14 {
+  def duplicate() = {}
+}

--- a/src/main/scala/jp/co/example/Util.scala
+++ b/src/main/scala/jp/co/example/Util.scala
@@ -6,4 +6,22 @@ object Util {
       case x :: xs => f(x) :: map(xs)(f)
       case Nil => Nil
   }
+
+  def append[T](a: List[T], b: List[T]): List[T] =
+     a match {
+       case Nil     => b
+       case x :: xs => x :: append(xs, b)
+     }
+
+  def foldLeft[A, B](list: List[A], b: B)(f: (B, A) => B): B = {
+       list match {
+         case x :: xs => foldLeft(xs, f(b, x))(f)
+         case Nil     => b
+       }
+     }
+
+  def flatMap[A, B](list: List[A])(f:A => List[B]):List[B] =
+    foldLeft(list, List[B]()){
+      (b, a) => append(b, f(a))
+    }
 }


### PR DESCRIPTION
### 設問
 Run-length encoding of a list (direct solution).
Implement the so-called run-length encoding data compression method directly. I.e. don't use other methods you've written (like P09's pack); do all the work directly.
Example:

scala> encodeDirect(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
res0: List[(Int, Symbol)] = List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e))